### PR TITLE
Add a README, and a change to reload.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+## What is it?
+
+This repository contains a color scheme template for wal, along with a script to run alongside wal to automatically change the color scheme for Neovim while it is running.
+
+## Usage
+
+1. Clone this repository by running: `git clone https://github.com/NvChad/pywal.git`
+2. Change into the pywal directory: `cd pywal`
+3. Run `python first_run.py` to copy the theme template into wals pywal template directory
+4. Run wal, specifying the -o option with the path to reload.py. For example: `wal -i /path/to/image.png -o ~/pywal/reload.py`

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This repository contains a color scheme template for wal, along with a script to
 2. Change into the pywal directory: `cd pywal`
 3. Run `python first_run.py` to copy the theme template into wals pywal template directory
 4. Run wal, specifying the -o option with the path to reload.py. For example: `wal -i /path/to/image.png -o ~/pywal/reload.py`
+5. Run neovim and press <leader>+th and set your theme to `wal`

--- a/reload.py
+++ b/reload.py
@@ -48,7 +48,5 @@ def reload_nvim():
         except Exception as e:
             print(f"Error connecting to Neovim at {socket}: {e}")
 
-copy_file("./base46-pywal.lua", f"{home_dir}/.config/wal/templates/base46-pywal.lua")
-
 copy_file(f"{home_dir}/.cache/wal/base46-pywal.lua", f"{home_dir}/.config/nvim/lua/themes/wal.lua")
 reload_nvim()


### PR DESCRIPTION
Hi,

Thanks for putting this up on github, I wanted to make it easier for other people to access by creating a short README.

I also made one small change to reload.py, I removed the copy_file call that copies the wal template into wals template directory. My reasoning was that first_run.py already does this, and that the copy requires you to run `wal -o reload.py` in the same directory as base46-pywal.lua, otherwise it prints "File not found". While it doesn't stop the script from working, it could create confusion.

Hopefully this is helpful :)